### PR TITLE
fix: when doing PR, the workflow is executed twice

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [prod, dev]
   pull_request:
-    types: [closed]
+    types: [opened]
 jobs:
   Test-and-Build:
     runs-on: ubuntu-latest
@@ -216,11 +216,12 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
             cd environments/${{ github.ref_name }}
+            terraform apply -var-file="secret.tfvars" -auto-approve
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            cd environments/${{ github.base_ref }} # target branch when merging the pull request
+            echo "***************************** SKIPPING APPLYING *******************************"
+            echo "Branch '${{ github.ref_name }}' does not represent an oficial environment [dev|prod]." Skip the deployment.
+            echo "*******************************************************************************"
           fi
-        
-          terraform apply -var-file="secret.tfvars" -auto-approve
   
   DeployCodeToS3:
     if: github.repository == 'timmytandian/remove-me-to-execute-this-job'

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -6,6 +6,10 @@ on:
     branches: [prod, dev]
   pull_request:
     types: [opened]
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   Test-and-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When doing PR, the workflow is executed twice (one on PR, the other one on merge/push). Make sure that when a PR is opened, it only create issue without deploying to Terraform. Deployment is done only on push.