### PR TITLE
fix: when doing PR, the workflow is executed twice (2nd try)

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [prod, dev]
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 permissions:
   pull-requests: write
   issues: write

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [prod, dev]
   pull_request:
-    types: [closed]
+    types: [opened]
 jobs:
   Test-and-Build:
     runs-on: ubuntu-latest
@@ -216,11 +216,12 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
             cd environments/${{ github.ref_name }}
+            terraform apply -var-file="secret.tfvars" -auto-approve
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            cd environments/${{ github.base_ref }} # target branch when merging the pull request
+            echo "***************************** SKIPPING APPLYING *******************************"
+            echo "Branch '${{ github.ref_name }}' does not represent an oficial environment [dev|prod]." Skip the deployment.
+            echo "*******************************************************************************"
           fi
-        
-          terraform apply -var-file="secret.tfvars" -auto-approve
   
   DeployCodeToS3:
     if: github.repository == 'timmytandian/remove-me-to-execute-this-job'

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -3,7 +3,7 @@ run-name: ACTOR ${{ github.actor }} - BRANCH ${{ github.ref_name }} - EVENT ${{ 
 on: 
   workflow_dispatch:
   push:
-    branches: [prod, dev, prod_pr_workflow]
+    branches: [prod, dev]
   pull_request:
     types: [opened]
 permissions:
@@ -187,7 +187,7 @@ jobs:
       #  Github script to to post issue in PR window
       #----------------------------------------------
       - uses: actions/github-script@v6
-        if: github.event_name == 'push'
+        if: github.event_name == 'pull_request'
         env:
           VALIDATE: ${{ steps.tf_validate.outputs.tf_validate_output }}
           PLAN: "${{ steps.tf_plan.outputs.tf_plan_output }}"

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -6,6 +6,10 @@ on:
     branches: [prod, dev]
   pull_request:
     types: [opened]
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   Test-and-Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -3,7 +3,7 @@ run-name: ACTOR ${{ github.actor }} - BRANCH ${{ github.ref_name }} - EVENT ${{ 
 on: 
   workflow_dispatch:
   push:
-    branches: [prod, dev]
+    branches: [prod, dev, prod_pr_workflow]
   pull_request:
     types: [opened]
 permissions:
@@ -158,7 +158,13 @@ jobs:
       #----------------------------------------------
       - name: Terraform Validate
         id: tf_validate
-        run: terraform validate -no-color
+        run: |
+          # Capture validate output to a file
+          terraform validate -no-color > validate.txt 2>&1
+          # Save the validate output to step outputs
+          echo "tf_validate_output<<EOF" >> $GITHUB_OUTPUT
+          cat validate.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: tf plan
         id: tf_plan
@@ -169,16 +175,22 @@ jobs:
             cd environments/${{ github.base_ref }} # target branch when merging the pull request
           fi
         
-          terraform plan -var-file="secret.tfvars"
+          # Capture the plan output to a file
+          terraform plan -var-file="secret.tfvars" > plan.txt 2>&1
+          # Save the plan output to step outputs
+          echo "tf_plan_output<<EOF" >> $GITHUB_OUTPUT
+          cat plan.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           cd ../../
 
       #----------------------------------------------
       #  Github script to to post issue in PR window
       #----------------------------------------------
       - uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         env:
-          PLAN: "terraform\n${{ steps.tf_plan.outputs.stdout }}"
+          VALIDATE: ${{ steps.tf_validate.outputs.tf_validate_output }}
+          PLAN: "${{ steps.tf_plan.outputs.tf_plan_output }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -188,7 +200,7 @@ jobs:
             <details><summary>Validation Output</summary>
       
             \`\`\`\n
-            ${{ steps.tf_validate.outputs.stdout }}
+            ${process.env.VALIDATE}
             \`\`\`
       
             </details>
@@ -223,7 +235,7 @@ jobs:
             terraform apply -var-file="secret.tfvars" -auto-approve
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "***************************** SKIPPING APPLYING *******************************"
-            echo "Branch '${{ github.ref_name }}' does not represent an oficial environment [dev|prod]." Skip the deployment.
+            echo "Branch '${{ github.head_ref }}' does not represent an oficial environment [dev|prod]." Skip the deployment.
             echo "*******************************************************************************"
           fi
   

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -160,7 +160,7 @@ jobs:
         id: tf_validate
         run: |
           # Capture validate output to a file
-          terraform validate -no-color > validate.txt 2>&1
+          terraform validate -no-color 2>&1 | tee validate.txt
           # Save the validate output to step outputs
           echo "tf_validate_output<<EOF" >> $GITHUB_OUTPUT
           cat validate.txt >> $GITHUB_OUTPUT
@@ -176,7 +176,7 @@ jobs:
           fi
         
           # Capture the plan output to a file
-          terraform plan -var-file="secret.tfvars" > plan.txt 2>&1
+          terraform plan -no-color -var-file="secret.tfvars" 2>&1 | tee plan.txt
           # Save the plan output to step outputs
           echo "tf_plan_output<<EOF" >> $GITHUB_OUTPUT
           cat plan.txt >> $GITHUB_OUTPUT


### PR DESCRIPTION
When doing PR, the workflow is executed twice (one on PR, the other one on merge/push). Make sure that when a PR is opened, it only create issue without deploying to Terraform. Deployment is done only on push.

Also I added permission block in the Github workflow